### PR TITLE
msg-appの氏名対応

### DIFF
--- a/server/msg-app/app/Http/Controllers/MessageController.php
+++ b/server/msg-app/app/Http/Controllers/MessageController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class MessageController extends Controller
+{
+    public function show($name, $msg)
+    {
+        $data = ['name' => $name, 'msg' => $msg];
+        return view('message.show', $data);
+    }
+}

--- a/server/msg-app/resources/views/message/show.blade.php
+++ b/server/msg-app/resources/views/message/show.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>msg-app</title>
+</head>
+<body>
+  <h1>変数に文字列が埋め込まれる</h1>
+  <h2>{{$name}}さん{{$msg}}</h2>
+</body>
+</html>

--- a/server/msg-app/routes/web.php
+++ b/server/msg-app/routes/web.php
@@ -14,3 +14,4 @@
 Route::get('/', function () {
     return view('welcome');
 });
+Route::get('message/{name}/{msg}', 'MessageController@show');


### PR DESCRIPTION
# msg-appの氏名対応

`http://localhost/ken/hello`にアクセスした場合、以下の画面が表示されます。


<img width="860" alt="スクリーンショット 2020-03-02 15 51 03" src="https://user-images.githubusercontent.com/5278718/75652135-a7058880-5c9d-11ea-9f5d-7a18a1833db3.png">
